### PR TITLE
Removes extra padding space at the top

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -243,21 +243,22 @@
 }
 
 .offline-notification {
+	width: 100%;
+	height: 0;
+	overflow: hidden;
 	background-color: #F44336;
 	color: #FFF;
 	z-index: 10;
 	text-align: center;
-	padding: 5px;
+	padding: 0;
 	font-size: 14px;
-	opacity: 0;
-	visibility: hidden;
 	-webkit-transition: all 1s ease;
 	transition: all 1s ease;
 }
 
 .offline-notification.offline {
-	opacity: 1;
-	visibility: visible;
+	height: auto;
+	padding: 5px;
 	-webkit-transition: all 1s ease;
 	transition: all 1s ease;
 }


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#1032

## Description
Now when the user is online block with warning has height: 0. If the user is offline block has height: auto. 
PS display: none/display: block do not have transition property, in that case, the transition would be instant. That's why I used height.

## Screenshots/screencasts
![rss demo ](https://user-images.githubusercontent.com/52824207/66128005-a638cf80-e5f5-11e9-8bda-13cd0a13b043.gif)

## Backward compatibility
This change is fully backward compatible.