### PR TITLE
Invalid URL warning is now not overlapped by display titles dropdown

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -111,12 +111,12 @@
   text-align: center;
   padding: 15px;
   color: #C56161;
-  background: rgba(242, 222, 222, 0.9);
+  background: #f2dede;
   border: 1px solid #C56161;
   position: absolute;
   top: 10px;
   left: 0;
-  z-index: 1;
+  z-index: 3;
 }
 
 #rss-feed-settings.failed .rss-fail {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5185

## Description
Added z-index. Changed background color to make opacity 1 to prevent it from being transparent.

## Screenshots/screencasts
<img width="381" alt="rss demo" src="https://user-images.githubusercontent.com/52824207/67989997-3beb6d00-fc3d-11e9-82f8-2bead02d67c2.png">

## Backward compatibility
This change is fully backward compatible.