### PR TITLE
Component now not disappears after clicking cancel

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -183,6 +183,12 @@ Fliplet.Widget.onSaveRequest(function() {
   save(true);
 });
 
+Fliplet.Widget.toggleCancelButton(false);
+Fliplet.Widget.onCancelRequest(function () {
+  Fliplet.Widget.complete();
+  Fliplet.Studio.emit('reload-page-preview');
+});
+
 function save(notifyComplete) {
 
   if (!(data.checkState === checkState.VALID)) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5256

## Description
Added Fliplet.Studio.emit('reload-page-preview') on cancel request.

## Screenshots/screencasts
![rss demo](https://user-images.githubusercontent.com/52824207/68945164-62baaf00-07b8-11ea-86fe-e7b5b93fbd6f.gif)

## Backward compatibility
This change is fully backward compatible.